### PR TITLE
CI: fix Trivy

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,8 +39,6 @@ jobs:
       SKIP: "gitleaks"
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
       - uses: actions/setup-python@v5
         with:
           python-version: "3.11"
@@ -58,8 +56,6 @@ jobs:
     needs: [build]
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
       - uses: actions/setup-python@v5
         with:
           python-version: "3.11"
@@ -111,7 +107,7 @@ jobs:
         with:
           image-ref: ${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}
           severity: "HIGH,CRITICAL"
-          vuln-type: "os"
+          vuln-type: "library"
           format: "table"
           exit-code: "1"
           ignore-unfixed: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -56,6 +56,7 @@ repos:
       args: [
         "--failure-threshold=warning",
         "--ignore=DL3008",
+        "--ignore=DL3013",
       ]
 
   - repo: https://github.com/astral-sh/ruff-pre-commit

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,7 @@ RUN useradd -mrU -d /home/app -s /bin/bash app
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends mailcap && \
+    pip install --no-cache-dir --upgrade pip setuptools && \
     rm -rf /var/lib/apt/lists/*
 
 USER app


### PR DESCRIPTION
Trivy should scan for "library" (Python) vulnerabilities instead of "os". We let the image maintainer update the image with the fixed versions for "os".