### PR TITLE
Public auth and Guest view

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -29,6 +29,7 @@ Content:
     - [Check API cache timeout](#check-api-cache-timeout)
   - [Gitlab](#gitlab)
     - [URL](#url)
+    - [Allow public](#allow-public)
     - [OAuth client id](#oauth-client-id)
     - [OAuth client secret](#oauth-client-secret)
     - [OAuth default token](#oauth-default-token)
@@ -308,6 +309,22 @@ Content:
     ```yaml
     gitlab:
       url: https://gitlab.example.com
+    ```
+
+#### Allow public
+
+- Type: boolean
+- Default: `False`
+- Environment variable:
+  - Name: `GITLAB_ALLOW_PUBLIC`
+  - Values: `true`, `false`
+- YAML:
+  - Path: `gitlab.allow-public`
+  - Example value:
+
+    ```yaml
+    gitlab:
+      allow-public: true
     ```
 
 #### OAuth client id

--- a/app/auth/depends.py
+++ b/app/auth/depends.py
@@ -24,7 +24,12 @@ from starlette.status import HTTP_401_UNAUTHORIZED, HTTP_500_INTERNAL_SERVER_ERR
 from app.session import SessionDep
 
 from .api import GitlabToken, oauth
-from .settings import GITLAB_OAUTH_DEFAULT_TOKEN, GITLAB_OAUTH_NAME, SESSION_AUTH_KEY
+from .settings import (
+    GITLAB_ALLOW_PUBLIC,
+    GITLAB_OAUTH_DEFAULT_TOKEN,
+    GITLAB_OAUTH_NAME,
+    SESSION_AUTH_KEY,
+)
 
 gitlab_token_query = APIKeyQuery(
     name="gitlab_token",
@@ -74,6 +79,12 @@ async def get_gitlab_token(
     elif GITLAB_OAUTH_DEFAULT_TOKEN:
         token = GitlabToken(
             value=GITLAB_OAUTH_DEFAULT_TOKEN,
+            query={},
+            rc_query={},
+        )
+    elif GITLAB_ALLOW_PUBLIC:
+        token = GitlabToken(
+            value="",
             query={},
             rc_query={},
         )

--- a/app/auth/settings.py
+++ b/app/auth/settings.py
@@ -15,7 +15,11 @@
 # limitations under the License.
 
 from app.settings import conf
+from app.utils.config import cbool
 
+GITLAB_ALLOW_PUBLIC: bool = conf(
+    "gitlab.allow-public", "GITLAB_ALLOW_PUBLIC", default=False, cast=cbool()
+)
 _CLIENT_ID: str | None = conf(
     "gitlab.oauth.client-id",
     "GITLAB_OAUTH_CLIENT_ID",

--- a/app/providers/client/gitlab.py
+++ b/app/providers/client/gitlab.py
@@ -76,6 +76,7 @@ GITLAB_LICENSES_SPDX_MAPPING = {
     "unlicense": "Unlicense",
 }
 
+GUEST_ACCESS_LEVEL = 10
 REPORTER_ACCESS_LEVEL = 20
 DEVELOPER_ACCESS_LEVEL = 30
 MAINTAINER_ACCESS_LEVEL = 40
@@ -1202,7 +1203,7 @@ def _adapt_graphql_project_preview(
 
 
 @no_type_check
-def _adapt_graphql_project(project_data: GitlabGraphQL_Project) -> Project:
+def _adapt_graphql_project(project_data: GitlabGraphQL_Project) -> Project:  # noqa: C901
     readme, metadata = _process_readme_and_metadata(project_data, save=False)
     default_branch = (
         project_data["repository"]["rootRef"] if project_data["repository"] else None
@@ -1279,7 +1280,9 @@ def _adapt_graphql_project(project_data: GitlabGraphQL_Project) -> Project:
     elif gitlab_access_level >= DEVELOPER_ACCESS_LEVEL:
         access_level = AccessLevel.CONTRIBUTOR
     elif gitlab_access_level >= REPORTER_ACCESS_LEVEL:
-        access_level = AccessLevel.VISITOR
+        access_level = AccessLevel.READ_ONLY
+    elif gitlab_access_level >= GUEST_ACCESS_LEVEL:
+        access_level = AccessLevel.GUEST
     else:
         access_level = AccessLevel.NO_ACCESS
 

--- a/app/providers/client/gitlab.py
+++ b/app/providers/client/gitlab.py
@@ -415,7 +415,9 @@ class GitlabClient(ProviderClient):
         self.api_url = f"{self.url}/api"
         self.rest_url = f"{self.api_url}/v4"
         self.graphql_url = f"{self.api_url}/graphql"
-        self.headers = {"Authorization": f"Bearer {token}"}
+        self.headers = {}
+        if token:
+            self.headers["Authorization"] = f"Bearer {token}"
         if headers:
             self.headers |= headers
 
@@ -435,7 +437,11 @@ class GitlabClient(ProviderClient):
             )
 
         graphql_data: dict[str, Any] = graphql_req["data"]
-        return graphql_data["currentUser"]["username"]
+        return (
+            graphql_data["currentUser"]["username"]
+            if graphql_data["currentUser"]
+            else "@public"
+        )
 
     async def get_topics(self) -> list[Topic]:
         _topics: list[GitlabREST_Topic] = await self._rest_iterate(

--- a/app/providers/schemas.py
+++ b/app/providers/schemas.py
@@ -29,9 +29,10 @@ logger = logging.getLogger("app")
 
 class AccessLevel(IntEnum):
     NO_ACCESS = 0
-    VISITOR = 1
-    CONTRIBUTOR = 2
-    ADMINISTRATOR = 3
+    GUEST = 1
+    READ_ONLY = 2
+    CONTRIBUTOR = 3
+    ADMINISTRATOR = 4
 
 
 class License(BaseModel):
@@ -107,7 +108,7 @@ class Project(ProjectPreview):
     # 1 for read-only (visitor)
     # 2 for modification allowed (contributor)
     # 3 for management permissions (administrator)
-    access_level: int = Field(ge=0, le=3)
+    access_level: int = Field(ge=0, le=4)
 
 
 class Topic(BaseModel):

--- a/app/stac/api/build.py
+++ b/app/stac/api/build.py
@@ -761,8 +761,13 @@ def _retrieve_extent(
 
 
 def _get_description(project: Project, **context: Unpack[STACContext]) -> str:
-    description = __resolve_links(project.readme, project, **context)
-    description = md.clean_new_lines(description)
+    if project.readme:
+        description = __resolve_links(project.readme, project, **context)
+        description = md.clean_new_lines(description)
+    elif project.description:
+        description = project.description
+    else:
+        description = ""
     return description
 
 


### PR DESCRIPTION
Close #16 #17

- Allow GitLab with public projects
- Use project description if no readme
- Rework access level:
  - No access: 0 (value also used when "public" browsing) 
  - Guest: 1
  - Read only: 2
  - Contributor: 3
  - Admin: 4

@okoko-cs modifications will be needed in [sharinghub-ui](https://github.com/csgroup-oss/sharinghub-ui)